### PR TITLE
meson.build: add Support for meson build system.

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,0 +1,1 @@
+install_man('xob.1')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,9 @@
+project('xob', 'c',
+  version : '0.1',
+  license : 'GPL-3.0-or-later')
+
+x11_dep = dependency('x11')
+libconfig_dep = dependency('libconfig')
+
+subdir('src')
+subdir('doc')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,12 @@
+xob_sources = [
+  'main.c',
+  'display.c',
+  'conf.c',
+]
+
+xob_executable = executable(
+  'xob',
+  xob_sources,
+  dependencies: [x11_dep, libconfig_dep],
+  install : true,
+)


### PR DESCRIPTION
These are the new file locations.

```
>>> xob
> /usr/bin/xob
> /usr/share/man/man1/xob.1
```