### PR TITLE
Small Makefile adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 LIBS    = x11 libconfig
-CFLAGS  = `pkg-config --cflags $(LIBS)` -std=c99 -Wall -Wextra -pedantic
-LDFLAGS = `pkg-config --libs $(LIBS)`
+CFLAGS  += $(shell pkg-config --cflags $(LIBS)) -std=c99 -Wall -Wextra -pedantic
+LDFLAGS += $(shell pkg-config --libs $(LIBS))
 
 PROGRAM = xob
 MANPAGE = doc/xob.1


### PR DESCRIPTION
Was trying to find a solution to #4, too, and though #7 fixes the issue the following small adjustments would make it even better :)

* append `CFLAGS` and `LFLAGS` to the ones the build environment of a distribution uses
* don’t use backticks but the shell function; backticks don’t seem to work in Void’s build environment
