### PR TITLE
Mention Source Mage GNU/Linux package for xob

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ xob depends on libx11 and libconfig.
 As of May 2019, there are packages for the following Linux distributions:
 
 * [Arch Linux package on the AUR](https://aur.archlinux.org/packages/xob/)
+* [Source Mage GNU/Linux](http://codex.sourcemage.org/test/wm-addons/xob)
 * [Void Linux package](https://github.com/void-linux/void-packages/tree/master/srcpkgs/xob)
 
 ## Usage


### PR DESCRIPTION
This mentions [SMGL](https://sourcemage.org) package for xob.