### PR TITLE
Better multi-monitor support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROGRAM = xob
 MANPAGE = doc/xob.1
 SYSCONF = styles.cfg
-LIBS    = x11 libconfig
+LIBS    = x11 libconfig xrandr
 SOURCES = src/conf.c src/display.c src/main.c
 
 # Feature: alpha channel (transparency)

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ When starting, xob looks for the configuration file in the following order:
 Consult the man page for detailed information about the configuration file and the available options. The following `styles.cfg` defines a single style called "default" that showcases all the possible options set to the default values. The configuration file may contain additional styles to choose among using the **-s** argument.
 
     default = {
+        monitor   = "auto";
         x         = {relative = 1; offset = -48;};
         y         = {relative = 0.5; offset = 0;};
         length    = {relative = 0.3; offset = 0;};
@@ -315,7 +316,7 @@ There is no support for panel integration. You can however use absolute position
 
 > "How about multiple monitors?"
 
-xob works well under multihead setups. The `monitor`, `x`, `y`, and `length` style options refer to the combined screen surface. By default the bar is vertical near the right edge of the rightmost monitor. In vertical layouts, you may prefer to switch the bar to horizontal mode as follows to avoid splits. By default options `x` and `y` use combined metrics for all your monitors, but you can specify a monitor to the bar, for example you can set option `monitor = "HDMI-1"` to show the bar only on `HDMI-1` (use `xrandr` command to get monitors names).
+xob works well under multihead setups. The `monitor`, `x`, `y`, and `length` style options refer to the combined screen surface. By default the bar is vertical near the right edge of the rightmost monitor. In vertical layouts, you may prefer to switch the bar to horizontal mode as follows to avoid splits. By default options `x` and `y` refer to the combined screen surface, but you can specify a monitor for the bar, for example you can set option `monitor = "HDMI-1"` to show the bar only on `HDMI-1` (use `xrandr` command to get monitors names).
 
     horizontal = {
         monitor   = "auto";

--- a/README.md
+++ b/README.md
@@ -315,9 +315,10 @@ There is no support for panel integration. You can however use absolute position
 
 > "How about multiple monitors?"
 
-xob works well under multihead setups. The `x`, `y`, and `length` style options refer to the combined screen surface. By default the bar is vertical near the right edge of the rightmost monitor. In vertical layouts, you may prefer to switch the bar to horizontal mode as follows to avoid splits.
+xob works well under multihead setups. The `monitor`, `x`, `y`, and `length` style options refer to the combined screen surface. By default the bar is vertical near the right edge of the rightmost monitor. In vertical layouts, you may prefer to switch the bar to horizontal mode as follows to avoid splits. By default options `x` and `y` use combined metrics for all your monitors, but you can specify a monitor to the bar, for example you can set option `monitor = "HDMI-1"` to show the bar only on `HDMI-1` (use `xrandr` command to get monitors names).
 
     horizontal = {
+        monitor   = "auto";
         x         = {relative = 0.5; offset = 0;};
         y         = {relative = 1; offset = -48;};
         orientation = "horizontal";

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ When starting, xob looks for the configuration file in the following order:
 Consult the man page for detailed information about the configuration file and the available options. The following `styles.cfg` defines a single style called "default" that showcases all the possible options set to the default values. The configuration file may contain additional styles to choose among using the **-s** argument.
 
     default = {
-        monitor   = "auto";
+        monitor   = "combined";
         x         = {relative = 1; offset = -48;};
         y         = {relative = 0.5; offset = 0;};
         length    = {relative = 0.3; offset = 0;};
@@ -319,7 +319,7 @@ There is no support for panel integration. You can however use absolute position
 xob works well under multihead setups. The default orientation of bar is `vertical` and is positioned at the right edge of the screen surface. By default, `x`, `y`, and `length` style options refer to the combined screen surface, but you can specify a monitor for the bar, for example you can set option `monitor = "HDMI-1"` to show the bar only on `HDMI-1` (use `xrandr` command to get monitors names). In vertical layouts, you may prefer to switch the bar to horizontal mode as follows to avoid splits.
 
     horizontal = {
-        monitor   = "auto";
+        monitor   = "combined";
         x         = {relative = 0.5; offset = 0;};
         y         = {relative = 1; offset = -48;};
         orientation = "horizontal";

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ There is no support for panel integration. You can however use absolute position
 
 > "How about multiple monitors?"
 
-xob works well under multihead setups. The `monitor`, `x`, `y`, and `length` style options refer to the combined screen surface. By default the bar is vertical near the right edge of the rightmost monitor. In vertical layouts, you may prefer to switch the bar to horizontal mode as follows to avoid splits. By default options `x` and `y` refer to the combined screen surface, but you can specify a monitor for the bar, for example you can set option `monitor = "HDMI-1"` to show the bar only on `HDMI-1` (use `xrandr` command to get monitors names).
+xob works well under multihead setups. The default orientation of bar is `vertical` and is positioned at the right edge of the screen surface. By default, `x`, `y`, and `length` style options refer to the combined screen surface, but you can specify a monitor for the bar, for example you can set option `monitor = "HDMI-1"` to show the bar only on `HDMI-1` (use `xrandr` command to get monitors names). In vertical layouts, you may prefer to switch the bar to horizontal mode as follows to avoid splits.
 
     horizontal = {
         monitor   = "auto";

--- a/doc/xob.1
+++ b/doc/xob.1
@@ -169,7 +169,7 @@ In the following, a dot \[lq].\[rq] means \[lq]suboption\[rq].
 For instance \[lq]color.normal.fg\[rq] means \[lq]The suboption fg of
 the suboption normal of option color\[rq].
 .TP
-\f[B]monitor\f[R] \f[I]\[lq]output_name\[rq]\f[R] (default: auto)
+\f[B]monitor\f[R] \f[I]\[lq]output_name\[rq]\f[R] (default: combined)
 Output monitor for the bar, use \f[I]xrandr\f[R] command to get monitors names.
 The option is case-sensitive.
 .TP
@@ -305,7 +305,7 @@ backlight = {
 .nf
 \f[C]
 default = {
-    monitor   = \[dq]auto\[dq];
+    monitor   = \[dq]combined\[dq];
     x         = {relative = 1; offset = -48;};
     y         = {relative = 0.5; offset = 0;};
     length    = {relative = 0.3; offset = 0;};
@@ -373,7 +373,7 @@ situations.
 .RE
 .PP
 xob works well under multihead setups, use option \f[I]monitor\f[R] to
-specify one. By default xob use \f[I]auto\f[R] for the option. It means
+specify one. By default xob use \f[I]combined\f[R] for the option. It means
 that in a dual monitor setup with the default configuration,
 the horizontal centering is not local to one of the two monitors.
 It is global. The bar might be split in two: one part on each screen.

--- a/doc/xob.1
+++ b/doc/xob.1
@@ -169,6 +169,10 @@ In the following, a dot \[lq].\[rq] means \[lq]suboption\[rq].
 For instance \[lq]color.normal.fg\[rq] means \[lq]The suboption fg of
 the suboption normal of option color\[rq].
 .TP
+\f[B]monitor\f[R] \f[I]\[lq]output_name\[rq]\f[R] (default: auto)
+Output monitor for the bar, use \f[I]xrandr\f[R] command to get monitors names.
+The option is case-sensitive.
+.TP
 \f[B]orientation\f[R] \f[I]\[lq]horizontal\[rq] | \[lq]vertical\[rq]\f[R] (default: vertical)
 Orientation of the bar which either fills up from left to right
 (\[lq]horizontal\[rq]) or bottom to top (\[lq]vertical\[rq]).
@@ -301,6 +305,7 @@ backlight = {
 .nf
 \f[C]
 default = {
+    monitor   = \[dq]auto\[dq];
     x         = {relative = 1; offset = -48;};
     y         = {relative = 0.5; offset = 0;};
     length    = {relative = 0.3; offset = 0;};
@@ -367,17 +372,17 @@ situations.
 \[lq]How to set up xob with multiple monitors?\[rq]
 .RE
 .PP
-xob works well under multihead setups but there is no easy way to
-configure the position of the bar for now.
-For example, in a dual monitor setup with the default configuration, the
-horizontal centering is not local to one of the two monitors.
-It is global.
-The bar might be split in two: one part on each screen.
-Stick to a corner or use absolute positioning.
-If you want an xob instance to be centered (horizontally) on the
-far-right monitor, set \f[I]x.relative\f[R] to 1.0 (anchored on the far
-right) and the \f[I]x.offset\f[R] to minus half the width of that
-screen.
+xob works well under multihead setups, use option \f[I]monitor\f[R] to
+specify one. By default xob use \f[I]auto\f[R] for the option. It means
+that in a dual monitor setup with the default configuration,
+the horizontal centering is not local to one of the two monitors.
+It is global. The bar might be split in two: one part on each screen.
+If you want an xob instance to be centered (horizontally) on the specific
+monitor, set \f[I]monitor\f[R] option to your monitor output,
+for example \f[I]monitor = \[lq]HDMI-1\[rq]\f[R] and set options
+\f[I]x.relative\f[R] and \f[I]y.relative\f[R] relative to the monitor.
+To get monitors output name you can use \f[I]xrandr --listmonitors\f[R]
+command in your terminal.
 .SH CONTRIBUTIONS
 .PP
 Feedback and contributions are welcome.

--- a/doc/xob.md
+++ b/doc/xob.md
@@ -104,6 +104,9 @@ Options can be grouped together inside curly brackets. Some options expect a gro
 
 In the following, a dot "." means "suboption". For instance "color.normal.fg" means "The suboption fg of the suboption normal of option color".
 
+**monitor** "output_name" (default: auto)
+:   Output monitor for the bar, use `xrandr` command to get monitors names. The option is case-sensitive.
+
 **orientation** *"horizontal" | "vertical"* (default: vertical)
 :   Orientation of the bar which either fills up from left to right ("horizontal") or bottom to top ("vertical").
 
@@ -194,6 +197,7 @@ This example configuration file provides two styles "volume" and "backlight". In
 ## DEFAULT CONFIGURATION FILE
 
     default = {
+        monitor   = "auto";
         x         = {relative = 1; offset = -48;};
         y         = {relative = 0.5; offset = 0;};
         length    = {relative = 0.3; offset = 0;};
@@ -242,7 +246,7 @@ There is no support for panel integration. You can however use absolute position
 
 > "How to set up xob with multiple monitors?"
 
-xob works well under multihead setups but there is no easy way to configure the position of the bar for now. For example, in a dual monitor setup with the default configuration, the horizontal centering is not local to one of the two monitors. It is global. The bar might be split in two: one part on each screen. Stick to a corner or use absolute positioning. If you want an xob instance to be centered (horizontally) on the far-right monitor, set *x.relative* to 1.0 (anchored on the far right) and the *x.offset* to minus half the width of that screen.
+xob works well under multihead setups, use option `monitor` to specify one. By default xob use `auto` for the option. It means that in a dual monitor setup with the default configuration, the horizontal centering is not local to one of the two monitors. It is global. The bar might be split in two: one part on each screen. If you want an xob instance to be centered (horizontally) on the specific monitor, set `monitor` option to your monitor output, for example `monitor = "HDMI-1"` and set options `x.relative` and `y.relative` relative to the monitor. To get monitors output name you can use `xrandr --listmonitors` command int your terminal.
 
 # CONTRIBUTIONS
 

--- a/doc/xob.md
+++ b/doc/xob.md
@@ -246,7 +246,7 @@ There is no support for panel integration. You can however use absolute position
 
 > "How to set up xob with multiple monitors?"
 
-xob works well under multihead setups, use option `monitor` to specify one. By default xob use `auto` for the option. It means that in a dual monitor setup with the default configuration, the horizontal centering is not local to one of the two monitors. It is global. The bar might be split in two: one part on each screen. If you want an xob instance to be centered (horizontally) on the specific monitor, set `monitor` option to your monitor output, for example `monitor = "HDMI-1"` and set options `x.relative` and `y.relative` relative to the monitor. To get monitors output name you can use `xrandr --listmonitors` command int your terminal.
+xob works well under multihead setups, use option `monitor` to specify one. By default xob use `auto` for the option. It means that in a dual monitor setup with the default configuration, the horizontal centering is not local to one of the two monitors. It is global. The bar might be split in two: one part on each screen. If you want an xob instance to be centered (horizontally) on the specific monitor, set `monitor` option to your monitor output, for example `monitor = "HDMI-1"` and set options `x.relative` and `y.relative` relative to the monitor. To get monitors output name you can use `xrandr --listmonitors` command in your terminal.
 
 # CONTRIBUTIONS
 

--- a/doc/xob.md
+++ b/doc/xob.md
@@ -104,7 +104,7 @@ Options can be grouped together inside curly brackets. Some options expect a gro
 
 In the following, a dot "." means "suboption". For instance "color.normal.fg" means "The suboption fg of the suboption normal of option color".
 
-**monitor** "output_name" (default: auto)
+**monitor** "output_name" (default: combined)
 :   Output monitor for the bar, use `xrandr` command to get monitors names. The option is case-sensitive.
 
 **orientation** *"horizontal" | "vertical"* (default: vertical)
@@ -197,7 +197,7 @@ This example configuration file provides two styles "volume" and "backlight". In
 ## DEFAULT CONFIGURATION FILE
 
     default = {
-        monitor   = "auto";
+        monitor   = "combined";
         x         = {relative = 1; offset = -48;};
         y         = {relative = 0.5; offset = 0;};
         length    = {relative = 0.3; offset = 0;};
@@ -246,7 +246,7 @@ There is no support for panel integration. You can however use absolute position
 
 > "How to set up xob with multiple monitors?"
 
-xob works well under multihead setups, use option `monitor` to specify one. By default xob use `auto` for the option. It means that in a dual monitor setup with the default configuration, the horizontal centering is not local to one of the two monitors. It is global. The bar might be split in two: one part on each screen. If you want an xob instance to be centered (horizontally) on the specific monitor, set `monitor` option to your monitor output, for example `monitor = "HDMI-1"` and set options `x.relative` and `y.relative` relative to the monitor. To get monitors output name you can use `xrandr --listmonitors` command in your terminal.
+xob works well under multihead setups, use option `monitor` to specify one. By default xob use `combined` for the option. It means that in a dual monitor setup with the default configuration, the horizontal centering is not local to one of the two monitors. It is global. The bar might be split in two: one part on each screen. If you want an xob instance to be centered (horizontally) on the specific monitor, set `monitor` option to your monitor output, for example `monitor = "HDMI-1"` and set options `x.relative` and `y.relative` relative to the monitor. To get monitors output name you can use `xrandr --listmonitors` command in your terminal.
 
 # CONTRIBUTIONS
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -229,6 +229,22 @@ static int config_setting_lookup_orientation(const config_setting_t *setting,
     return success_status;
 }
 
+static int config_setting_lookup_monitor(const config_setting_t *setting,
+                                         const char *name, char *monitorvalue)
+{
+    const char *stringvalue;
+
+    if (config_setting_lookup_string(setting, name, &stringvalue))
+    {
+        strncpy(monitorvalue, stringvalue, LNAME_MONITOR);
+    }
+    else
+    {
+        fprintf(stderr, "Error: No style %s.\n", name);
+    }
+    return CONFIG_TRUE;
+}
+
 Style parse_style_config(FILE *file, const char *stylename, Style default_style)
 {
     config_t config;
@@ -243,6 +259,8 @@ Style parse_style_config(FILE *file, const char *stylename, Style default_style)
         xob_config = config_lookup(&config, stylename);
         if (xob_config != NULL)
         {
+            config_setting_lookup_monitor(xob_config, "monitor",
+                                         style.monitor);
             config_setting_lookup_int(xob_config, "thickness",
                                       &style.thickness);
             config_setting_lookup_int(xob_config, "border", &style.border);

--- a/src/conf.h
+++ b/src/conf.h
@@ -20,6 +20,9 @@
 
 #include <stdio.h>
 
+#define MONITOR_AUTO "auto"
+#define LNAME_MONITOR 12
+
 typedef struct
 {
     unsigned char red;
@@ -63,6 +66,7 @@ typedef enum
 
 typedef struct
 {
+    char monitor[LNAME_MONITOR];
     Dim x;
     Dim y;
     Dim length;
@@ -77,6 +81,7 @@ typedef struct
 
 /* clang-format off */
 #define DEFAULT_CONFIGURATION (Style) {\
+        .monitor = MONITOR_AUTO,\
         .x =\
         {\
             .rel = 1.0,\

--- a/src/conf.h
+++ b/src/conf.h
@@ -20,7 +20,7 @@
 
 #include <stdio.h>
 
-#define MONITOR_AUTO "auto"
+#define MONITOR_COMBINED "combined"
 #define LNAME_MONITOR 12
 
 typedef struct
@@ -81,7 +81,7 @@ typedef struct
 
 /* clang-format off */
 #define DEFAULT_CONFIGURATION (Style) {\
-        .monitor = MONITOR_AUTO,\
+        .monitor = MONITOR_COMBINED,\
         .x =\
         {\
             .rel = 1.0,\

--- a/src/display.c
+++ b/src/display.c
@@ -19,6 +19,7 @@
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <X11/extensions/Xrandr.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -115,18 +116,18 @@ void compute_geometry(Style conf, Display_context *dc, int *topleft_x,
                *available_length - 2 * *fat_layer);
 
     /* Compute position of the top-left corner */
-    *topleft_x = fit_in(WidthOfScreen(dc->x.screen) * conf.x.rel -
+    *topleft_x = fit_in(dc->x.monitor_info.width * conf.x.rel -
                             (size_x(dc->geometry) + 2 * *fat_layer) / 2,
                         0,
-                        WidthOfScreen(dc->x.screen) -
+                        dc->x.monitor_info.width -
                             (size_x(dc->geometry) + 2 * *fat_layer)) +
-                 conf.x.abs;
-    *topleft_y = fit_in(HeightOfScreen(dc->x.screen) * conf.y.rel -
+                 conf.x.abs + dc->x.monitor_info.x;
+    *topleft_y = fit_in(dc->x.monitor_info.height * conf.y.rel -
                             (size_y(dc->geometry) + 2 * *fat_layer) / 2,
                         0,
-                        HeightOfScreen(dc->x.screen) -
+                        dc->x.monitor_info.width -
                             (size_y(dc->geometry) + 2 * *fat_layer)) +
-                 conf.y.abs;
+                 conf.y.abs + dc->x.monitor_info.y;
 }
 
 /* PUBLIC Returns a new display context from a given configuration. If the
@@ -158,6 +159,40 @@ Display_context init(Style conf)
             XCreateColormap(dc.x.display, root, dc_depth.visuals, AllocNone);
         window_attributes.border_pixel = 0;
         window_attributes.override_redirect = True;
+
+        /* Get monitors info */
+        char *hard_monitor = "eDP-1";
+        int num_monitors;
+        char *monitor_name;
+        XRRMonitorInfo *monitor_sizes = XRRGetMonitors(
+                dc.x.display, root, 0, &num_monitors);
+        int i;
+        for (i = 0; i < num_monitors; i++)
+        {
+            monitor_name = XGetAtomName(dc.x.display, monitor_sizes[i].name);
+            if (strcmp(hard_monitor, monitor_name) == 0)
+                break;
+        }
+        if (i == num_monitors)
+        {
+            /* Fallback monitor if no monitor with provided name found*/
+            fprintf(stderr, "Monitor %s is not found. Use FULL mode\n",
+                    monitor_name);
+            dc.x.monitor_info.x = 0;
+            dc.x.monitor_info.y = 0;
+            dc.x.monitor_info.width = WidthOfScreen(dc.x.screen);
+            dc.x.monitor_info.height = HeightOfScreen(dc.x.screen);
+            strcpy(dc.x.monitor_info.name, "FULL");
+        }
+        else
+        {
+            dc.x.monitor_info.x = monitor_sizes[i].x;
+            dc.x.monitor_info.y = monitor_sizes[i].y;
+            dc.x.monitor_info.width = monitor_sizes[i].width;
+            dc.x.monitor_info.height = monitor_sizes[i].height;
+            strcpy(dc.x.monitor_info.name, monitor_name);
+        }
+        XRRFreeMonitors(monitor_sizes);
 
         compute_geometry(conf, &dc, &topleft_x, &topleft_y, &fat_layer,
                          &available_length);

--- a/src/display.c
+++ b/src/display.c
@@ -160,7 +160,7 @@ Display_context init(Style conf)
         window_attributes.border_pixel = 0;
         window_attributes.override_redirect = True;
 
-        if (strcmp(conf.monitor, MONITOR_AUTO) != 0)
+        if (strcmp(conf.monitor, MONITOR_COMBINED) != 0)
         {
             /* Get monitors info */
             int num_monitors;
@@ -177,15 +177,16 @@ Display_context init(Style conf)
             }
             if (i == num_monitors) // Monitor name is not found
             {
-                /* Use auto for monitor option if no monitors with
+                /* Use combined for monitor option if no monitors with
                  * provided name found*/
-                fprintf(stderr, "Monitor %s is not found. Use FULL mode\n",
-                        monitor_name);
+                fprintf(stderr, "Error: monitor %s is not found.\n",
+                        conf.monitor);
+                fprintf(stderr, "Info: falling back to combined mode.\n");
                 dc.x.monitor_info.x = 0;
                 dc.x.monitor_info.y = 0;
                 dc.x.monitor_info.width = WidthOfScreen(dc.x.screen);
                 dc.x.monitor_info.height = HeightOfScreen(dc.x.screen);
-                strcpy(dc.x.monitor_info.name, MONITOR_AUTO);
+                strcpy(dc.x.monitor_info.name, MONITOR_COMBINED);
             }
             else
             {
@@ -203,7 +204,7 @@ Display_context init(Style conf)
             dc.x.monitor_info.y = 0;
             dc.x.monitor_info.width = WidthOfScreen(dc.x.screen);
             dc.x.monitor_info.height = HeightOfScreen(dc.x.screen);
-            strcpy(dc.x.monitor_info.name, MONITOR_AUTO);
+            strcpy(dc.x.monitor_info.name, MONITOR_COMBINED);
         }
 
         compute_geometry(conf, &dc, &topleft_x, &topleft_y, &fat_layer,

--- a/src/display.c
+++ b/src/display.c
@@ -125,7 +125,7 @@ void compute_geometry(Style conf, Display_context *dc, int *topleft_x,
     *topleft_y = fit_in(dc->x.monitor_info.height * conf.y.rel -
                             (size_y(dc->geometry) + 2 * *fat_layer) / 2,
                         0,
-                        dc->x.monitor_info.width -
+                        dc->x.monitor_info.height -
                             (size_y(dc->geometry) + 2 * *fat_layer)) +
                  conf.y.abs + dc->x.monitor_info.y;
 }

--- a/src/display.c
+++ b/src/display.c
@@ -108,8 +108,8 @@ void compute_geometry(Style conf, Display_context *dc, int *topleft_x,
 
     /* Orientation-related dimensions */
     *available_length = dc->geometry.orientation == HORIZONTAL
-                            ? WidthOfScreen(dc->x.screen)
-                            : HeightOfScreen(dc->x.screen);
+                            ? dc->x.monitor_info.width
+                            : dc->x.monitor_info.height;
 
     dc->geometry.length =
         fit_in(*available_length * conf.length.rel + conf.length.abs, 0,
@@ -177,7 +177,7 @@ Display_context init(Style conf)
             }
             if (i == num_monitors) // Monitor name is not found
             {
-                /* Use auto for monitor option if no monitor with
+                /* Use auto for monitor option if no monitors with
                  * provided name found*/
                 fprintf(stderr, "Monitor %s is not found. Use FULL mode\n",
                         monitor_name);

--- a/src/display.h
+++ b/src/display.h
@@ -29,11 +29,21 @@ typedef enum
 
 typedef struct
 {
+    char name[10];
+    int x;
+    int y;
+    int width;
+    int height;
+} MonitorInfo;
+
+typedef struct
+{
     Display *display;
     int screen_number;
     Screen *screen;
     Window window;
     Bool mapped;
+    MonitorInfo monitor_info;
 } X_context;
 
 typedef struct

--- a/styles.cfg
+++ b/styles.cfg
@@ -1,4 +1,5 @@
 default = {
+    monitor   = "auto";
     x         = {relative = 1; offset = -48;};
     y         = {relative = 0.5; offset = 0;};
     length    = {relative = 0.3; offset = 0;};

--- a/styles.cfg
+++ b/styles.cfg
@@ -1,5 +1,5 @@
 default = {
-    monitor   = "auto";
+    monitor   = "combined";
     x         = {relative = 1; offset = -48;};
     y         = {relative = 0.5; offset = 0;};
     length    = {relative = 0.3; offset = 0;};


### PR DESCRIPTION
This changes add ability to set specific monitor for the bar. I've only added `xrandr` lib, that probably already installed in almost all systems with X11.
Now you can set specific monitor to any bar in a config with option `monitor`. If `monitor` option is defined then options `x`, `y` and `length` will be relative to the specific monitor, otherwise will be relative to the combined screen surface.
Option `monitor` accepts output names from `xrandr` command.