### PR TITLE
Feature/relative multimonitor position

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROGRAM = xob
 MANPAGE = doc/xob.1
 SYSCONF = styles.cfg
-LIBS    = x11 libconfig
+LIBS    = x11 libconfig xrandr
 SOURCES = src/conf.c src/display.c src/main.c
 
 # Feature: alpha channel (transparency)

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ When starting, xob looks for the configuration file in the following order:
 Consult the man page for detailed information about the configuration file and the available options. The following `styles.cfg` defines a single style called "default" that showcases all the possible options set to the default values. The configuration file may contain additional styles to choose among using the **-s** argument.
 
     default = {
+        monitor   = "auto";
         x         = {relative = 1; offset = -48;};
         y         = {relative = 0.5; offset = 0;};
         length    = {relative = 0.3; offset = 0;};
@@ -315,7 +316,7 @@ There is no support for panel integration. You can however use absolute position
 
 > "How about multiple monitors?"
 
-xob works well under multihead setups. The `monitor`, `x`, `y`, and `length` style options refer to the combined screen surface. By default the bar is vertical near the right edge of the rightmost monitor. In vertical layouts, you may prefer to switch the bar to horizontal mode as follows to avoid splits. By default options `x` and `y` use combined metrics for all your monitors, but you can specify a monitor to the bar, for example you can set option `monitor = "HDMI-1"` to show the bar only on `HDMI-1` (use `xrandr` command to get monitors names).
+xob works well under multihead setups. The `monitor`, `x`, `y`, and `length` style options refer to the combined screen surface. By default the bar is vertical near the right edge of the rightmost monitor. In vertical layouts, you may prefer to switch the bar to horizontal mode as follows to avoid splits. By default options `x` and `y` refer to the combined screen surface, but you can specify a monitor for the bar, for example you can set option `monitor = "HDMI-1"` to show the bar only on `HDMI-1` (use `xrandr` command to get monitors names).
 
     horizontal = {
         monitor   = "auto";

--- a/README.md
+++ b/README.md
@@ -315,9 +315,10 @@ There is no support for panel integration. You can however use absolute position
 
 > "How about multiple monitors?"
 
-xob works well under multihead setups. The `x`, `y`, and `length` style options refer to the combined screen surface. By default the bar is vertical near the right edge of the rightmost monitor. In vertical layouts, you may prefer to switch the bar to horizontal mode as follows to avoid splits.
+xob works well under multihead setups. The `monitor`, `x`, `y`, and `length` style options refer to the combined screen surface. By default the bar is vertical near the right edge of the rightmost monitor. In vertical layouts, you may prefer to switch the bar to horizontal mode as follows to avoid splits. By default options `x` and `y` use combined metrics for all your monitors, but you can specify a monitor to the bar, for example you can set option `monitor = "HDMI-1"` to show the bar only on `HDMI-1` (use `xrandr` command to get monitors names).
 
     horizontal = {
+        monitor   = "auto";
         x         = {relative = 0.5; offset = 0;};
         y         = {relative = 1; offset = -48;};
         orientation = "horizontal";

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ When starting, xob looks for the configuration file in the following order:
 Consult the man page for detailed information about the configuration file and the available options. The following `styles.cfg` defines a single style called "default" that showcases all the possible options set to the default values. The configuration file may contain additional styles to choose among using the **-s** argument.
 
     default = {
-        monitor   = "auto";
+        monitor   = "combined";
         x         = {relative = 1; offset = -48;};
         y         = {relative = 0.5; offset = 0;};
         length    = {relative = 0.3; offset = 0;};
@@ -319,7 +319,7 @@ There is no support for panel integration. You can however use absolute position
 xob works well under multihead setups. The default orientation of bar is `vertical` and is positioned at the right edge of the screen surface. By default, `x`, `y`, and `length` style options refer to the combined screen surface, but you can specify a monitor for the bar, for example you can set option `monitor = "HDMI-1"` to show the bar only on `HDMI-1` (use `xrandr` command to get monitors names). In vertical layouts, you may prefer to switch the bar to horizontal mode as follows to avoid splits.
 
     horizontal = {
-        monitor   = "auto";
+        monitor   = "combined";
         x         = {relative = 0.5; offset = 0;};
         y         = {relative = 1; offset = -48;};
         orientation = "horizontal";

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ There is no support for panel integration. You can however use absolute position
 
 > "How about multiple monitors?"
 
-xob works well under multihead setups. The `monitor`, `x`, `y`, and `length` style options refer to the combined screen surface. By default the bar is vertical near the right edge of the rightmost monitor. In vertical layouts, you may prefer to switch the bar to horizontal mode as follows to avoid splits. By default options `x` and `y` refer to the combined screen surface, but you can specify a monitor for the bar, for example you can set option `monitor = "HDMI-1"` to show the bar only on `HDMI-1` (use `xrandr` command to get monitors names).
+xob works well under multihead setups. The default orientation of bar is `vertical` and is positioned at the right edge of the screen surface. By default, `x`, `y`, and `length` style options refer to the combined screen surface, but you can specify a monitor for the bar, for example you can set option `monitor = "HDMI-1"` to show the bar only on `HDMI-1` (use `xrandr` command to get monitors names). In vertical layouts, you may prefer to switch the bar to horizontal mode as follows to avoid splits.
 
     horizontal = {
         monitor   = "auto";

--- a/doc/xob.1
+++ b/doc/xob.1
@@ -169,7 +169,7 @@ In the following, a dot \[lq].\[rq] means \[lq]suboption\[rq].
 For instance \[lq]color.normal.fg\[rq] means \[lq]The suboption fg of
 the suboption normal of option color\[rq].
 .TP
-\f[B]monitor\f[R] \f[I]\[lq]output_name\[rq]\f[R] (default: auto)
+\f[B]monitor\f[R] \f[I]\[lq]output_name\[rq]\f[R] (default: combined)
 Output monitor for the bar, use \f[I]xrandr\f[R] command to get monitors names.
 The option is case-sensitive.
 .TP
@@ -305,7 +305,7 @@ backlight = {
 .nf
 \f[C]
 default = {
-    monitor   = \[dq]auto\[dq];
+    monitor   = \[dq]combined\[dq];
     x         = {relative = 1; offset = -48;};
     y         = {relative = 0.5; offset = 0;};
     length    = {relative = 0.3; offset = 0;};
@@ -373,7 +373,7 @@ situations.
 .RE
 .PP
 xob works well under multihead setups, use option \f[I]monitor\f[R] to
-specify one. By default xob use \f[I]auto\f[R] for the option. It means
+specify one. By default xob use \f[I]combined\f[R] for the option. It means
 that in a dual monitor setup with the default configuration,
 the horizontal centering is not local to one of the two monitors.
 It is global. The bar might be split in two: one part on each screen.

--- a/doc/xob.1
+++ b/doc/xob.1
@@ -169,6 +169,10 @@ In the following, a dot \[lq].\[rq] means \[lq]suboption\[rq].
 For instance \[lq]color.normal.fg\[rq] means \[lq]The suboption fg of
 the suboption normal of option color\[rq].
 .TP
+\f[B]monitor\f[R] \f[I]\[lq]output_name\[rq]\f[R] (default: auto)
+Output monitor for the bar, use \f[I]xrandr\f[R] command to get monitors names.
+The option is case-sensitive.
+.TP
 \f[B]orientation\f[R] \f[I]\[lq]horizontal\[rq] | \[lq]vertical\[rq]\f[R] (default: vertical)
 Orientation of the bar which either fills up from left to right
 (\[lq]horizontal\[rq]) or bottom to top (\[lq]vertical\[rq]).
@@ -301,6 +305,7 @@ backlight = {
 .nf
 \f[C]
 default = {
+    monitor   = \[dq]auto\[dq];
     x         = {relative = 1; offset = -48;};
     y         = {relative = 0.5; offset = 0;};
     length    = {relative = 0.3; offset = 0;};
@@ -367,17 +372,17 @@ situations.
 \[lq]How to set up xob with multiple monitors?\[rq]
 .RE
 .PP
-xob works well under multihead setups but there is no easy way to
-configure the position of the bar for now.
-For example, in a dual monitor setup with the default configuration, the
-horizontal centering is not local to one of the two monitors.
-It is global.
-The bar might be split in two: one part on each screen.
-Stick to a corner or use absolute positioning.
-If you want an xob instance to be centered (horizontally) on the
-far-right monitor, set \f[I]x.relative\f[R] to 1.0 (anchored on the far
-right) and the \f[I]x.offset\f[R] to minus half the width of that
-screen.
+xob works well under multihead setups, use option \f[I]monitor\f[R] to
+specify one. By default xob use \f[I]auto\f[R] for the option. It means
+that in a dual monitor setup with the default configuration,
+the horizontal centering is not local to one of the two monitors.
+It is global. The bar might be split in two: one part on each screen.
+If you want an xob instance to be centered (horizontally) on the specific
+monitor, set \f[I]monitor\f[R] option to your monitor output,
+for example \f[I]monitor = \[lq]HDMI-1\[rq]\f[R] and set options
+\f[I]x.relative\f[R] and \f[I]y.relative\f[R] relative to the monitor.
+To get monitors output name you can use \f[I]xrandr --listmonitors\f[R]
+command in your terminal.
 .SH CONTRIBUTIONS
 .PP
 Feedback and contributions are welcome.

--- a/doc/xob.1
+++ b/doc/xob.1
@@ -169,9 +169,12 @@ In the following, a dot \[lq].\[rq] means \[lq]suboption\[rq].
 For instance \[lq]color.normal.fg\[rq] means \[lq]The suboption fg of
 the suboption normal of option color\[rq].
 .TP
-\f[B]monitor\f[R] \f[I]\[lq]output_name\[rq]\f[R] (default: combined)
+\f[B]monitor\f[R] \f[I]\[lq]output_name\[rq] | \[lq]relative_focus\[rq] | \[lq]relative_pointer\[rq] | \[lq]combined\[rq]\f[R] (default: combined)
 Output monitor for the bar, use \f[I]xrandr\f[R] command to get monitors names.
-The option is case-sensitive.
+Use \f[I]relative_focus\f[R] to show the bar on the monitor with a focused window.
+Use \f[I]relative_pointer\f[R] to show the bar on the monitor with a mouse
+pointer. Use \f[I]combined\f[R] to show the bar on the combined surface of all
+monitors. The option is case-sensitive.
 .TP
 \f[B]orientation\f[R] \f[I]\[lq]horizontal\[rq] | \[lq]vertical\[rq]\f[R] (default: vertical)
 Orientation of the bar which either fills up from left to right

--- a/doc/xob.md
+++ b/doc/xob.md
@@ -104,6 +104,9 @@ Options can be grouped together inside curly brackets. Some options expect a gro
 
 In the following, a dot "." means "suboption". For instance "color.normal.fg" means "The suboption fg of the suboption normal of option color".
 
+**monitor** "output_name" (default: auto)
+:   Output monitor for the bar, use `xrandr` command to get monitors names. The option is case-sensitive.
+
 **orientation** *"horizontal" | "vertical"* (default: vertical)
 :   Orientation of the bar which either fills up from left to right ("horizontal") or bottom to top ("vertical").
 
@@ -194,6 +197,7 @@ This example configuration file provides two styles "volume" and "backlight". In
 ## DEFAULT CONFIGURATION FILE
 
     default = {
+        monitor   = "auto";
         x         = {relative = 1; offset = -48;};
         y         = {relative = 0.5; offset = 0;};
         length    = {relative = 0.3; offset = 0;};
@@ -242,7 +246,7 @@ There is no support for panel integration. You can however use absolute position
 
 > "How to set up xob with multiple monitors?"
 
-xob works well under multihead setups but there is no easy way to configure the position of the bar for now. For example, in a dual monitor setup with the default configuration, the horizontal centering is not local to one of the two monitors. It is global. The bar might be split in two: one part on each screen. Stick to a corner or use absolute positioning. If you want an xob instance to be centered (horizontally) on the far-right monitor, set *x.relative* to 1.0 (anchored on the far right) and the *x.offset* to minus half the width of that screen.
+xob works well under multihead setups, use option `monitor` to specify one. By default xob use `auto` for the option. It means that in a dual monitor setup with the default configuration, the horizontal centering is not local to one of the two monitors. It is global. The bar might be split in two: one part on each screen. If you want an xob instance to be centered (horizontally) on the specific monitor, set `monitor` option to your monitor output, for example `monitor = "HDMI-1"` and set options `x.relative` and `y.relative` relative to the monitor. To get monitors output name you can use `xrandr --listmonitors` command int your terminal.
 
 # CONTRIBUTIONS
 

--- a/doc/xob.md
+++ b/doc/xob.md
@@ -246,7 +246,7 @@ There is no support for panel integration. You can however use absolute position
 
 > "How to set up xob with multiple monitors?"
 
-xob works well under multihead setups, use option `monitor` to specify one. By default xob use `auto` for the option. It means that in a dual monitor setup with the default configuration, the horizontal centering is not local to one of the two monitors. It is global. The bar might be split in two: one part on each screen. If you want an xob instance to be centered (horizontally) on the specific monitor, set `monitor` option to your monitor output, for example `monitor = "HDMI-1"` and set options `x.relative` and `y.relative` relative to the monitor. To get monitors output name you can use `xrandr --listmonitors` command int your terminal.
+xob works well under multihead setups, use option `monitor` to specify one. By default xob use `auto` for the option. It means that in a dual monitor setup with the default configuration, the horizontal centering is not local to one of the two monitors. It is global. The bar might be split in two: one part on each screen. If you want an xob instance to be centered (horizontally) on the specific monitor, set `monitor` option to your monitor output, for example `monitor = "HDMI-1"` and set options `x.relative` and `y.relative` relative to the monitor. To get monitors output name you can use `xrandr --listmonitors` command in your terminal.
 
 # CONTRIBUTIONS
 

--- a/doc/xob.md
+++ b/doc/xob.md
@@ -104,7 +104,7 @@ Options can be grouped together inside curly brackets. Some options expect a gro
 
 In the following, a dot "." means "suboption". For instance "color.normal.fg" means "The suboption fg of the suboption normal of option color".
 
-**monitor** "output_name" (default: auto)
+**monitor** "output_name" (default: combined)
 :   Output monitor for the bar, use `xrandr` command to get monitors names. The option is case-sensitive.
 
 **orientation** *"horizontal" | "vertical"* (default: vertical)
@@ -197,7 +197,7 @@ This example configuration file provides two styles "volume" and "backlight". In
 ## DEFAULT CONFIGURATION FILE
 
     default = {
-        monitor   = "auto";
+        monitor   = "combined";
         x         = {relative = 1; offset = -48;};
         y         = {relative = 0.5; offset = 0;};
         length    = {relative = 0.3; offset = 0;};
@@ -246,7 +246,7 @@ There is no support for panel integration. You can however use absolute position
 
 > "How to set up xob with multiple monitors?"
 
-xob works well under multihead setups, use option `monitor` to specify one. By default xob use `auto` for the option. It means that in a dual monitor setup with the default configuration, the horizontal centering is not local to one of the two monitors. It is global. The bar might be split in two: one part on each screen. If you want an xob instance to be centered (horizontally) on the specific monitor, set `monitor` option to your monitor output, for example `monitor = "HDMI-1"` and set options `x.relative` and `y.relative` relative to the monitor. To get monitors output name you can use `xrandr --listmonitors` command in your terminal.
+xob works well under multihead setups, use option `monitor` to specify one. By default xob use `combined` for the option. It means that in a dual monitor setup with the default configuration, the horizontal centering is not local to one of the two monitors. It is global. The bar might be split in two: one part on each screen. If you want an xob instance to be centered (horizontally) on the specific monitor, set `monitor` option to your monitor output, for example `monitor = "HDMI-1"` and set options `x.relative` and `y.relative` relative to the monitor. To get monitors output name you can use `xrandr --listmonitors` command in your terminal.
 
 # CONTRIBUTIONS
 

--- a/doc/xob.md
+++ b/doc/xob.md
@@ -104,8 +104,8 @@ Options can be grouped together inside curly brackets. Some options expect a gro
 
 In the following, a dot "." means "suboption". For instance "color.normal.fg" means "The suboption fg of the suboption normal of option color".
 
-**monitor** "output_name" (default: combined)
-:   Output monitor for the bar, use `xrandr` command to get monitors names. The option is case-sensitive.
+**monitor** *"output_name" | "relative_focus" | "relative_pointer" | "combined"* (default: combined)
+:   Output monitor for the bar, use `xrandr` command to get monitors names. Use "relative_focus" to show the bar on the monitor with a focused window. Use "relative_pointer" to show the bar on the monitor with a mouse pointer. Use "combined" to show the bar on the combined surface of all monitors. The option is case-sensitive.
 
 **orientation** *"horizontal" | "vertical"* (default: vertical)
 :   Orientation of the bar which either fills up from left to right ("horizontal") or bottom to top ("vertical").
@@ -159,7 +159,6 @@ Each of the following have three suboptions ".fg", ".bg", and ".border" correspo
 
 
 ## STYLES
-
 All the options described above must be encompassed inside a style specification. A style consists of a group of all or some of the options described above. The name of the style is the name of an option at the root level of the configuration file. When an option is missing from a style, the default values are used instead. A configuration file may specify several styles (at least 1) to choose using the **-s** argument.
 
 This example configuration file provides two styles "volume" and "backlight". Instances of xog launched with **-s volume** and **-s backlight** will look according to the corresponding style.

--- a/src/conf.c
+++ b/src/conf.c
@@ -259,8 +259,7 @@ Style parse_style_config(FILE *file, const char *stylename, Style default_style)
         xob_config = config_lookup(&config, stylename);
         if (xob_config != NULL)
         {
-            config_setting_lookup_monitor(xob_config, "monitor",
-                                         style.monitor);
+            config_setting_lookup_monitor(xob_config, "monitor", style.monitor);
             config_setting_lookup_int(xob_config, "thickness",
                                       &style.thickness);
             config_setting_lookup_int(xob_config, "border", &style.border);

--- a/src/conf.c
+++ b/src/conf.c
@@ -229,6 +229,22 @@ static int config_setting_lookup_orientation(const config_setting_t *setting,
     return success_status;
 }
 
+static int config_setting_lookup_monitor(const config_setting_t *setting,
+                                         const char *name, char *monitorvalue)
+{
+    const char *stringvalue;
+
+    if (config_setting_lookup_string(setting, name, &stringvalue))
+    {
+        strncpy(monitorvalue, stringvalue, LNAME_MONITOR);
+    }
+    else
+    {
+        fprintf(stderr, "Error: No style %s.\n", name);
+    }
+    return CONFIG_TRUE;
+}
+
 Style parse_style_config(FILE *file, const char *stylename, Style default_style)
 {
     config_t config;
@@ -243,6 +259,8 @@ Style parse_style_config(FILE *file, const char *stylename, Style default_style)
         xob_config = config_lookup(&config, stylename);
         if (xob_config != NULL)
         {
+            config_setting_lookup_monitor(xob_config, "monitor",
+                                         style.monitor);
             config_setting_lookup_int(xob_config, "thickness",
                                       &style.thickness);
             config_setting_lookup_int(xob_config, "border", &style.border);

--- a/src/conf.h
+++ b/src/conf.h
@@ -24,7 +24,7 @@
 #define MONITOR_RELATIVE_POINTER "relative_pointer"
 #define MONITOR_COMBINED "combined"
 
-#define LNAME_MONITOR 12
+#define LNAME_MONITOR 17
 
 typedef struct
 {

--- a/src/conf.h
+++ b/src/conf.h
@@ -20,6 +20,9 @@
 
 #include <stdio.h>
 
+#define MONITOR_AUTO "auto"
+#define LNAME_MONITOR 12
+
 typedef struct
 {
     unsigned char red;
@@ -63,6 +66,7 @@ typedef enum
 
 typedef struct
 {
+    char monitor[LNAME_MONITOR];
     Dim x;
     Dim y;
     Dim length;
@@ -77,6 +81,7 @@ typedef struct
 
 /* clang-format off */
 #define DEFAULT_CONFIGURATION (Style) {\
+        .monitor = MONITOR_AUTO,\
         .x =\
         {\
             .rel = 1.0,\

--- a/src/conf.h
+++ b/src/conf.h
@@ -20,7 +20,10 @@
 
 #include <stdio.h>
 
+#define MONITOR_RELATIVE_FOCUS "relative_focus"
+#define MONITOR_RELATIVE_POINTER "relative_pointer"
 #define MONITOR_COMBINED "combined"
+
 #define LNAME_MONITOR 12
 
 typedef struct

--- a/src/conf.h
+++ b/src/conf.h
@@ -20,7 +20,7 @@
 
 #include <stdio.h>
 
-#define MONITOR_AUTO "auto"
+#define MONITOR_COMBINED "combined"
 #define LNAME_MONITOR 12
 
 typedef struct
@@ -81,7 +81,7 @@ typedef struct
 
 /* clang-format off */
 #define DEFAULT_CONFIGURATION (Style) {\
-        .monitor = MONITOR_AUTO,\
+        .monitor = MONITOR_COMBINED,\
         .x =\
         {\
             .rel = 1.0,\

--- a/src/display.c
+++ b/src/display.c
@@ -144,8 +144,8 @@ static void draw_content(X_context x, Geometry_context g, int filled_length,
 
         /* Fill background color */
         fill_rectangle(x, colors.bg, g.outline + g.border + g.padding,
-                       g.outline + g.border + g.padding,
-                       g.thickness, g.length - filled_length);
+                       g.outline + g.border + g.padding, g.thickness,
+                       g.length - filled_length);
     }
 }
 

--- a/src/display.c
+++ b/src/display.c
@@ -19,6 +19,7 @@
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <X11/extensions/Xrandr.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -115,18 +116,18 @@ void compute_geometry(Style conf, Display_context *dc, int *topleft_x,
                *available_length - 2 * *fat_layer);
 
     /* Compute position of the top-left corner */
-    *topleft_x = fit_in(WidthOfScreen(dc->x.screen) * conf.x.rel -
+    *topleft_x = fit_in(dc->x.monitor_info.width * conf.x.rel -
                             (size_x(dc->geometry) + 2 * *fat_layer) / 2,
                         0,
-                        WidthOfScreen(dc->x.screen) -
+                        dc->x.monitor_info.width -
                             (size_x(dc->geometry) + 2 * *fat_layer)) +
-                 conf.x.abs;
-    *topleft_y = fit_in(HeightOfScreen(dc->x.screen) * conf.y.rel -
+                 conf.x.abs + dc->x.monitor_info.x;
+    *topleft_y = fit_in(dc->x.monitor_info.height * conf.y.rel -
                             (size_y(dc->geometry) + 2 * *fat_layer) / 2,
                         0,
-                        HeightOfScreen(dc->x.screen) -
+                        dc->x.monitor_info.width -
                             (size_y(dc->geometry) + 2 * *fat_layer)) +
-                 conf.y.abs;
+                 conf.y.abs + dc->x.monitor_info.y;
 }
 
 /* PUBLIC Returns a new display context from a given configuration. If the
@@ -158,6 +159,40 @@ Display_context init(Style conf)
             XCreateColormap(dc.x.display, root, dc_depth.visuals, AllocNone);
         window_attributes.border_pixel = 0;
         window_attributes.override_redirect = True;
+
+        /* Get monitors info */
+        char *hard_monitor = "eDP-1";
+        int num_monitors;
+        char *monitor_name;
+        XRRMonitorInfo *monitor_sizes = XRRGetMonitors(
+                dc.x.display, root, 0, &num_monitors);
+        int i;
+        for (i = 0; i < num_monitors; i++)
+        {
+            monitor_name = XGetAtomName(dc.x.display, monitor_sizes[i].name);
+            if (strcmp(hard_monitor, monitor_name) == 0)
+                break;
+        }
+        if (i == num_monitors)
+        {
+            /* Fallback monitor if no monitor with provided name found*/
+            fprintf(stderr, "Monitor %s is not found. Use FULL mode\n",
+                    monitor_name);
+            dc.x.monitor_info.x = 0;
+            dc.x.monitor_info.y = 0;
+            dc.x.monitor_info.width = WidthOfScreen(dc.x.screen);
+            dc.x.monitor_info.height = HeightOfScreen(dc.x.screen);
+            strcpy(dc.x.monitor_info.name, "FULL");
+        }
+        else
+        {
+            dc.x.monitor_info.x = monitor_sizes[i].x;
+            dc.x.monitor_info.y = monitor_sizes[i].y;
+            dc.x.monitor_info.width = monitor_sizes[i].width;
+            dc.x.monitor_info.height = monitor_sizes[i].height;
+            strcpy(dc.x.monitor_info.name, monitor_name);
+        }
+        XRRFreeMonitors(monitor_sizes);
 
         compute_geometry(conf, &dc, &topleft_x, &topleft_y, &fat_layer,
                          &available_length);

--- a/src/display.c
+++ b/src/display.c
@@ -160,7 +160,7 @@ Display_context init(Style conf)
         window_attributes.border_pixel = 0;
         window_attributes.override_redirect = True;
 
-        if (strcmp(conf.monitor, MONITOR_AUTO) != 0)
+        if (strcmp(conf.monitor, MONITOR_COMBINED) != 0)
         {
             /* Get monitors info */
             int num_monitors;
@@ -177,15 +177,16 @@ Display_context init(Style conf)
             }
             if (i == num_monitors) // Monitor name is not found
             {
-                /* Use auto for monitor option if no monitors with
+                /* Use combined for monitor option if no monitors with
                  * provided name found*/
-                fprintf(stderr, "Monitor %s is not found. Use FULL mode\n",
-                        monitor_name);
+                fprintf(stderr, "Error: monitor %s is not found.\n",
+                        conf.monitor);
+                fprintf(stderr, "Info: falling back to combined mode.\n");
                 dc.x.monitor_info.x = 0;
                 dc.x.monitor_info.y = 0;
                 dc.x.monitor_info.width = WidthOfScreen(dc.x.screen);
                 dc.x.monitor_info.height = HeightOfScreen(dc.x.screen);
-                strcpy(dc.x.monitor_info.name, MONITOR_AUTO);
+                strcpy(dc.x.monitor_info.name, MONITOR_COMBINED);
             }
             else
             {
@@ -203,7 +204,7 @@ Display_context init(Style conf)
             dc.x.monitor_info.y = 0;
             dc.x.monitor_info.width = WidthOfScreen(dc.x.screen);
             dc.x.monitor_info.height = HeightOfScreen(dc.x.screen);
-            strcpy(dc.x.monitor_info.name, MONITOR_AUTO);
+            strcpy(dc.x.monitor_info.name, MONITOR_COMBINED);
         }
 
         compute_geometry(conf, &dc, &topleft_x, &topleft_y, &fat_layer,

--- a/src/display.c
+++ b/src/display.c
@@ -45,34 +45,107 @@ static int size_y(Geometry_context g)
 static void draw_empty(X_context x, Geometry_context g, Colors colors)
 {
     /* Outline */
+#ifdef _DEBUG_
+    // fill_rectangle(x, colors.bg, 0, 0,
+    //                2 * (g.outline + g.border + g.padding) + size_x(g),
+    //                2 * (g.outline + g.border + g.padding) + size_y(g));
+#endif
+    /* Left */
+    fill_rectangle(x, colors.bg, 0, 0, g.outline,
+                   2 * (g.outline + g.border + g.padding) + size_y(g));
+
+    /* Right */
+    fill_rectangle(
+        x, colors.bg, 2 * (g.border + g.padding) + g.outline + size_x(g), 0,
+        g.outline, 2 * (g.outline + g.border + g.padding) + size_y(g));
+
+    /* Top */
     fill_rectangle(x, colors.bg, 0, 0,
                    2 * (g.outline + g.border + g.padding) + size_x(g),
-                   2 * (g.outline + g.border + g.padding) + size_y(g));
+                   g.outline);
+
+    /* Bottom */
+    fill_rectangle(
+        x, colors.bg, 0, 2 * (g.border + g.padding) + g.outline + size_y(g),
+        2 * (g.outline + g.border + g.padding) + size_x(g), g.outline);
+
     /* Border */
+#ifdef _DEBUG_
     fill_rectangle(x, colors.border, g.outline, g.outline,
                    2 * (g.border + g.padding) + size_x(g),
                    2 * (g.border + g.padding) + size_y(g));
+#endif
+    /* Left */
+    fill_rectangle(x, colors.border, g.outline, g.outline, g.border,
+                   2 * (g.border + g.padding) + size_y(g));
+
+    /* Right */
+    fill_rectangle(x, colors.border,
+                   g.outline + g.border + 2 * g.padding + size_x(g), g.outline,
+                   g.border, 2 * (g.border + g.padding) + size_y(g));
+
+    /* Top */
+    fill_rectangle(x, colors.border, g.outline, g.outline,
+                   2 * (g.border + g.padding) + size_x(g), g.border);
+
+    /* Bottom */
+    fill_rectangle(x, colors.border, g.outline,
+                   g.outline + g.border + 2 * g.padding + size_y(g),
+                   2 * (g.border + g.padding) + size_x(g), g.border);
+
     /* Padding */
+#ifdef _DEBUG_
     fill_rectangle(x, colors.bg, g.outline + g.border, g.outline + g.border,
                    2 * g.padding + size_x(g), 2 * g.padding + size_y(g));
+#endif
+
+    /* Left */
+    fill_rectangle(x, colors.bg, g.outline + g.border, g.outline + g.border,
+                   g.padding, 2 * g.padding + size_y(g));
+
+    /* Right */
+    fill_rectangle(x, colors.bg, g.outline + g.border + g.padding + size_x(g),
+                   g.outline + g.border, g.padding, 2 * g.padding + size_y(g));
+
+    /* Top */
+    fill_rectangle(x, colors.bg, g.outline + g.border, g.outline + g.border,
+                   2 * g.padding + size_x(g), g.padding);
+
+    /* Bottom */
+    fill_rectangle(x, colors.bg, g.outline + g.border,
+                   g.outline + g.border + g.padding + size_y(g),
+                   2 * g.padding + size_x(g), g.padding);
 }
 
 /* Draw a given length of filled bar with the given color */
 static void draw_content(X_context x, Geometry_context g, int filled_length,
-                         Color color)
+                         Colors colors)
 {
     if (g.orientation == HORIZONTAL)
     {
-        fill_rectangle(x, color, g.outline + g.border + g.padding,
+        /* Fill foreground color */
+        fill_rectangle(x, colors.fg, g.outline + g.border + g.padding,
                        g.outline + g.border + g.padding, filled_length,
                        g.thickness);
+
+        /* Fill background color */
+        fill_rectangle(x, colors.bg,
+                       g.outline + g.border + g.padding + filled_length,
+                       g.outline + g.border + g.padding,
+                       g.length - filled_length, g.thickness);
     }
     else
     {
-        fill_rectangle(x, color, g.outline + g.border + g.padding,
+        /* fill foreground color */
+        fill_rectangle(x, colors.fg, g.outline + g.border + g.padding,
                        g.outline + g.border + g.padding + g.length -
                            filled_length,
                        g.thickness, filled_length);
+
+        /* Fill background color */
+        fill_rectangle(x, colors.bg, g.outline + g.border + g.padding,
+                       g.outline + g.border + g.padding,
+                       g.thickness, g.length - filled_length);
     }
 }
 
@@ -165,13 +238,13 @@ Display_context init(Style conf)
             /* Get monitors info */
             int num_monitors;
             char *monitor_name;
-            XRRMonitorInfo *monitor_sizes = XRRGetMonitors(
-                    dc.x.display, root, 0, &num_monitors);
+            XRRMonitorInfo *monitor_sizes =
+                XRRGetMonitors(dc.x.display, root, 0, &num_monitors);
             int i;
             for (i = 0; i < num_monitors; i++)
             {
-                monitor_name = XGetAtomName(dc.x.display,
-                                            monitor_sizes[i].name);
+                monitor_name =
+                    XGetAtomName(dc.x.display, monitor_sizes[i].name);
                 if (strcmp(conf.monitor, monitor_name) == 0)
                     break;
             }
@@ -283,14 +356,14 @@ Display_context show(Display_context dc, int value, int cap,
 
     /* Content */
     draw_content(dc.x, dc.geometry,
-                 fit_in(value, 0, cap) * dc.geometry.length / cap, colors.fg);
+                 fit_in(value, 0, cap) * dc.geometry.length / cap, colors);
 
     /* Proportional overflow : draw separator */
     if (value > cap && overflow_mode == PROPORTIONAL &&
         cap * dc.geometry.length / value > dc.geometry.padding)
     {
         draw_content(dc.x, dc.geometry, cap * dc.geometry.length / value,
-                     colors_overflow_proportional.fg);
+                     colors_overflow_proportional);
         draw_separator(dc.x, dc.geometry, cap * dc.geometry.length / value,
                        colors.bg);
     }

--- a/src/display.c
+++ b/src/display.c
@@ -202,19 +202,19 @@ static void move_to_coords_monitor(const Display_context * pdc, int x, int y)
                 y > monitor_sizes[i].y &&
                 y < monitor_sizes[i].y + monitor_sizes[i].height)
         {
-            topleft_x = fit_in(monitor_sizes[i].width * pdc->x.x_rel -
+            topleft_x = fit_in(monitor_sizes[i].width * pdc->geometry.x.rel -
                             (size_x(pdc->geometry) + 2 * fat_layer) / 2,
                             0,
                             monitor_sizes[i].width -
                             (size_x(pdc->geometry) + 2 * fat_layer)) +
-                                pdc->x.x_abs + monitor_sizes[i].x;
+                                pdc->geometry.x.abs + monitor_sizes[i].x;
 
-            topleft_y = fit_in(monitor_sizes[i].height * pdc->x.y_rel -
+            topleft_y = fit_in(monitor_sizes[i].height * pdc->geometry.y.rel -
                             (size_y(pdc->geometry) + 2 * fat_layer) / 2,
                             0,
                             monitor_sizes[i].height -
                             (size_y(pdc->geometry) + 2 * fat_layer)) +
-                                pdc->x.y_abs + monitor_sizes[i].y;
+                                pdc->geometry.y.abs + monitor_sizes[i].y;
 
             XMoveWindow(pdc->x.display, pdc->x.window,
                     topleft_x, topleft_y);
@@ -289,22 +289,22 @@ Display_context init(Style conf)
         window_attributes.override_redirect = True;
 
         /* Write bar position relative data to X_context */
-        dc.x.x_rel = conf.x.rel;
-        dc.x.x_abs = conf.x.abs;
-        dc.x.y_rel = conf.y.rel;
-        dc.x.y_abs = conf.y.abs;
+        dc.geometry.x.rel = conf.x.rel;
+        dc.geometry.x.abs = conf.x.abs;
+        dc.geometry.y.rel = conf.y.rel;
+        dc.geometry.y.abs = conf.y.abs;
 
         /* Get bar position from conf */
         if (strcmp(conf.monitor, MONITOR_RELATIVE_FOCUS) == 0)
-            dc.x.bar_position = POSITION_RELATIVE_FOCUS;
+            dc.geometry.bar_position = POSITION_RELATIVE_FOCUS;
         else if (strcmp(conf.monitor, MONITOR_RELATIVE_POINTER) == 0)
-            dc.x.bar_position = POSITION_RELATIVE_POINTER;
+            dc.geometry.bar_position = POSITION_RELATIVE_POINTER;
         else if (strcmp(conf.monitor, MONITOR_COMBINED) == 0)
-            dc.x.bar_position = POSITION_COMBINED;
+            dc.geometry.bar_position = POSITION_COMBINED;
         else
-            dc.x.bar_position = POSITION_SPECIFIED;
+            dc.geometry.bar_position = POSITION_SPECIFIED;
 
-        switch (dc.x.bar_position)
+        switch (dc.geometry.bar_position)
         {
             case POSITION_COMBINED:
                 set_combined_position(&dc);
@@ -363,7 +363,7 @@ Display_context show(Display_context dc, int value, int cap,
     Colors colors_overflow_proportional;
 
     /* Move the bar for relative positions */
-    // switch (dc.x.bar_position)
+    // switch (dc.geometry.bar_position)
     switch (POSITION_RELATIVE_POINTER)
     {
         case POSITION_RELATIVE_FOCUS:

--- a/src/display.c
+++ b/src/display.c
@@ -125,7 +125,7 @@ void compute_geometry(Style conf, Display_context *dc, int *topleft_x,
     *topleft_y = fit_in(dc->x.monitor_info.height * conf.y.rel -
                             (size_y(dc->geometry) + 2 * *fat_layer) / 2,
                         0,
-                        dc->x.monitor_info.width -
+                        dc->x.monitor_info.height -
                             (size_y(dc->geometry) + 2 * *fat_layer)) +
                  conf.y.abs + dc->x.monitor_info.y;
 }

--- a/src/display.c
+++ b/src/display.c
@@ -463,16 +463,16 @@ void show(Display_context *pdc, int value, int cap, Overflow_mode overflow_mode,
     static int_fast8_t current_state = 0x0;
     static int_fast8_t last_state = 0x0;
 
+    int old_length = pdc->geometry.length;
+
     /* Move the bar for relative positions */
     switch (pdc->geometry.bar_position)
     {
     case POSITION_RELATIVE_FOCUS:
         move_resize_to_focused_monitor(pdc);
-        current_state ^= STATE_SIZE;
         break;
     case POSITION_RELATIVE_POINTER:
         move_resize_to_pointer_monitor(pdc);
-        current_state ^= STATE_SIZE;
         break;
     case POSITION_COMBINED:
     case POSITION_SPECIFIED:
@@ -522,7 +522,8 @@ void show(Display_context *pdc, int value, int cap, Overflow_mode overflow_mode,
         break;
     }
 
-    if (last_state != current_state)
+    /* Redraw empty bar only if needed */
+    if (last_state != current_state || old_length != pdc->geometry.length)
     {
         /* Empty bar */
         draw_empty(pdc->x, pdc->geometry, colors);

--- a/src/display.c
+++ b/src/display.c
@@ -491,7 +491,10 @@ Display_context show(Display_context dc, int value, int cap,
         if (value <= cap)
             colors = dc.colorscheme.normal;
         else
+        {
             colors = dc.colorscheme.overflow;
+            colors_overflow_proportional.bg = colors.fg;
+        }
         break;
 
     case ALTERNATIVE:
@@ -499,16 +502,15 @@ Display_context show(Display_context dc, int value, int cap,
         if (value <= cap)
             colors = dc.colorscheme.alt;
         else
+        {
             colors = dc.colorscheme.altoverflow;
+            colors_overflow_proportional.bg = colors.fg;
+        }
         break;
     }
 
     /* Empty bar */
     draw_empty(dc.x, dc.geometry, colors);
-
-    /* Content */
-    draw_content(dc.x, dc.geometry,
-                 fit_in(value, 0, cap) * dc.geometry.length / cap, colors);
 
     /* Proportional overflow : draw separator */
     if (value > cap && overflow_mode == PROPORTIONAL &&
@@ -519,6 +521,10 @@ Display_context show(Display_context dc, int value, int cap,
         draw_separator(dc.x, dc.geometry, cap * dc.geometry.length / value,
                        colors.bg);
     }
+    else // Value is less then cap
+        /* Content */
+        draw_content(dc.x, dc.geometry,
+                     fit_in(value, 0, cap) * dc.geometry.length / cap, colors);
 
     XFlush(dc.x.display);
 

--- a/src/display.c
+++ b/src/display.c
@@ -108,8 +108,8 @@ void compute_geometry(Style conf, Display_context *dc, int *topleft_x,
 
     /* Orientation-related dimensions */
     *available_length = dc->geometry.orientation == HORIZONTAL
-                            ? WidthOfScreen(dc->x.screen)
-                            : HeightOfScreen(dc->x.screen);
+                            ? dc->x.monitor_info.width
+                            : dc->x.monitor_info.height;
 
     dc->geometry.length =
         fit_in(*available_length * conf.length.rel + conf.length.abs, 0,
@@ -177,7 +177,7 @@ Display_context init(Style conf)
             }
             if (i == num_monitors) // Monitor name is not found
             {
-                /* Use auto for monitor option if no monitor with
+                /* Use auto for monitor option if no monitors with
                  * provided name found*/
                 fprintf(stderr, "Monitor %s is not found. Use FULL mode\n",
                         monitor_name);

--- a/src/display.c
+++ b/src/display.c
@@ -144,36 +144,6 @@ static void set_combined_position(Display_context *pdc)
     // strcpy(pdc->x.monitor_info.name, MONITOR_COMBINED);
 }
 
-/* Set bar size relative to the first monitor */
-static void set_relative_position(Display_context *pdc)
-{
-    Window root = RootWindow(pdc->x.display, pdc->x.screen_number);
-
-    /* Get monitors info */
-    int num_monitors;
-    XRRMonitorInfo *monitor_sizes =
-        XRRGetMonitors(pdc->x.display, root, 0, &num_monitors);
-
-    /* Set monitor_info for the first monitor */
-    if (num_monitors != 0)
-    {
-        pdc->x.monitor_info.x = monitor_sizes[0].x;
-        pdc->x.monitor_info.y = monitor_sizes[0].y;
-        pdc->x.monitor_info.width = monitor_sizes[0].width;
-        pdc->x.monitor_info.height = monitor_sizes[0].height;
-    }
-    else // Monitor name is not found
-    {
-        /* Use combined surface for monitor option if no monitors with
-         * provided name found */
-        fprintf(stderr, "Error: Can't get monitors info.\n");
-        fprintf(stderr, "Info: falling back to combined mode.\n");
-        set_combined_position(pdc);
-        // strcpy(pdc.x.monitor_info.name, MONITOR_COMBINED);
-    }
-    XRRFreeMonitors(monitor_sizes);
-}
-
 /* Set specified monitor */
 static void set_specified_position(Display_context *pdc, const Style *pconf)
 {
@@ -350,7 +320,10 @@ Display_context init(Style conf)
         {
         case POSITION_RELATIVE_FOCUS:
         case POSITION_RELATIVE_POINTER:
-            set_relative_position(&dc);
+            /* Bar position and sizes will be recalculated every time before
+             * showing, so the code just init position and sizes like for
+             * combined surface */
+            set_combined_position(&dc);
             break;
         case POSITION_COMBINED:
             set_combined_position(&dc);

--- a/src/display.c
+++ b/src/display.c
@@ -198,10 +198,10 @@ static void move_resize_to_coords_monitor(Display_context *pdc, int x, int y)
         &num_monitors);
     for (i = 0; i < num_monitors; i++)
     {
-        /* Find monitor by coordinates of focused window */
-        if (x > monitor_sizes[i].x &&
+        /* Find monitor by coords */
+        if (x >= monitor_sizes[i].x &&
             x < monitor_sizes[i].x + monitor_sizes[i].width &&
-            y > monitor_sizes[i].y &&
+            y >= monitor_sizes[i].y &&
             y < monitor_sizes[i].y + monitor_sizes[i].height)
         {
             /* Recalculate bar sizes */
@@ -243,6 +243,8 @@ static void move_resize_to_focused_monitor(Display_context *pdc)
 {
     int revert_to_window;
     int focused_x, focused_y;
+    int dummy_x, dummy_y;
+    unsigned int focused_width, focused_height, focused_border, focused_depth;
 
     Window focused_window, fchild_window;
 
@@ -252,8 +254,14 @@ static void move_resize_to_focused_monitor(Display_context *pdc)
     XTranslateCoordinates(pdc->x.display, focused_window,
                           RootWindow(pdc->x.display, pdc->x.screen_number), 0,
                           0, &focused_x, &focused_y, &fchild_window);
+    /* Get focused window width and height to move bar relative to
+     * the center of focused window */
+    XGetGeometry(pdc->x.display, focused_window, &fchild_window, &dummy_x,
+                 &dummy_y, &focused_width, &focused_height, &focused_border,
+                 &focused_depth);
 
-    move_resize_to_coords_monitor(pdc, focused_x, focused_y);
+    move_resize_to_coords_monitor(pdc, focused_x + focused_width / 2,
+                                  focused_y + focused_height / 2);
 }
 
 /* Move the bar to monitor with pointer */

--- a/src/display.h
+++ b/src/display.h
@@ -61,12 +61,19 @@ typedef struct
     int border;
     int padding;
     int length;
+    struct
+    {
+        double rel;
+        int abs;
+    } length_dynamic;
     int thickness;
-    struct {
+    struct
+    {
         double rel;
         int abs;
     } x;
-    struct {
+    struct
+    {
         double rel;
         int abs;
     } y;

--- a/src/display.h
+++ b/src/display.h
@@ -25,6 +25,7 @@
 #define STATE_ALT (0x1)
 #define STATE_OVERFLOW (0x1 << 1)
 #define STATE_SIZE (0x1 << 2)
+#define STATE_MAPPED (0x1 << 3)
 
 typedef enum
 {
@@ -93,10 +94,10 @@ typedef struct
 } Display_context;
 
 Display_context init(Style conf);
-Display_context show(Display_context dc, int value, int cap,
-                     Overflow_mode overflow_mode, Show_mode show_mode);
-Display_context hide(Display_context dc);
-void display_context_destroy(Display_context dc);
+void show(Display_context *pdc, int value, int cap, Overflow_mode overflow_mode,
+          Show_mode show_mode);
+void hide(Display_context *pdc);
+void display_context_destroy(Display_context *pdc);
 
 /* Draw a rectangle with the given size, position and color */
 void fill_rectangle(X_context xc, Color c, int x, int y, unsigned int w,

--- a/src/display.h
+++ b/src/display.h
@@ -53,11 +53,6 @@ typedef struct
     Window window;
     Bool mapped;
     MonitorInfo monitor_info;
-    Bar_position bar_position;
-    double x_rel;
-    int x_abs;
-    double y_rel;
-    int y_abs;
 } X_context;
 
 typedef struct
@@ -67,6 +62,15 @@ typedef struct
     int padding;
     int length;
     int thickness;
+    struct {
+        double rel;
+        int abs;
+    } x;
+    struct {
+        double rel;
+        int abs;
+    } y;
+    Bar_position bar_position;
     Orientation orientation;
 } Geometry_context;
 

--- a/src/display.h
+++ b/src/display.h
@@ -22,6 +22,10 @@
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>
 
+#define STATE_ALT (0x1)
+#define STATE_OVERFLOW (0x1 << 1)
+#define STATE_SIZE (0x1 << 2)
+
 typedef enum
 {
     POSITION_RELATIVE_FOCUS,

--- a/src/display.h
+++ b/src/display.h
@@ -24,8 +24,7 @@
 
 #define STATE_ALT (0x1)
 #define STATE_OVERFLOW (0x1 << 1)
-#define STATE_SIZE (0x1 << 2)
-#define STATE_MAPPED (0x1 << 3)
+#define STATE_MAPPED (0x1 << 2)
 
 typedef enum
 {

--- a/src/display.h
+++ b/src/display.h
@@ -54,6 +54,10 @@ typedef struct
     Bool mapped;
     MonitorInfo monitor_info;
     Bar_position bar_position;
+    double x_rel;
+    int x_abs;
+    double y_rel;
+    int y_abs;
 } X_context;
 
 typedef struct

--- a/src/display.h
+++ b/src/display.h
@@ -20,6 +20,15 @@
 
 #include "conf.h"
 #include <X11/Xlib.h>
+#include <X11/extensions/Xrandr.h>
+
+typedef enum
+{
+    POSITION_RELATIVE_FOCUS,
+    POSITION_RELATIVE_POINTER,
+    POSITION_COMBINED,
+    POSITION_SPECIFIED
+} Bar_position;
 
 typedef enum
 {
@@ -44,6 +53,7 @@ typedef struct
     Window window;
     Bool mapped;
     MonitorInfo monitor_info;
+    Bar_position bar_position;
 } X_context;
 
 typedef struct

--- a/src/display.h
+++ b/src/display.h
@@ -29,11 +29,21 @@ typedef enum
 
 typedef struct
 {
+    char name[10];
+    int x;
+    int y;
+    int width;
+    int height;
+} MonitorInfo;
+
+typedef struct
+{
     Display *display;
     int screen_number;
     Screen *screen;
     Window window;
     Bool mapped;
+    MonitorInfo monitor_info;
 } X_context;
 
 typedef struct

--- a/src/main.c
+++ b/src/main.c
@@ -206,7 +206,7 @@ int main(int argc, char *argv[])
                 exit(EXIT_FAILURE);
             case 0:
                 /* Time to hide the gauge */
-                display_context = hide(display_context);
+                hide(&display_context);
                 displayed = false;
                 break;
             default:
@@ -214,9 +214,8 @@ int main(int argc, char *argv[])
                 input_value = parse_input();
                 if (input_value.valid)
                 {
-                    display_context =
-                        show(display_context, input_value.value, cap,
-                             style.overflow, input_value.show_mode);
+                    show(&display_context, input_value.value, cap,
+                         style.overflow, input_value.show_mode);
                     printf("Update: %d/%d %s\n", input_value.value, cap,
                            (input_value.show_mode == ALTERNATIVE) ? "[ALT]"
                                                                   : "");
@@ -233,7 +232,7 @@ int main(int argc, char *argv[])
         }
 
         /* Clean the memory */
-        display_context_destroy(display_context);
+        display_context_destroy(&display_context);
     }
     return EXIT_SUCCESS;
 }

--- a/styles.cfg
+++ b/styles.cfg
@@ -1,4 +1,5 @@
 default = {
+    monitor   = "auto";
     x         = {relative = 1; offset = -48;};
     y         = {relative = 0.5; offset = 0;};
     length    = {relative = 0.3; offset = 0;};

--- a/styles.cfg
+++ b/styles.cfg
@@ -1,5 +1,5 @@
 default = {
-    monitor   = "auto";
+    monitor   = "combined";
     x         = {relative = 1; offset = -48;};
     y         = {relative = 0.5; offset = 0;};
     length    = {relative = 0.3; offset = 0;};


### PR DESCRIPTION
Continuation of [the pull request #43](https://github.com/florentc/xob/pull/43).
This push request adds ability to change position of the bar dynamically. In config of the bar in `monitor` field you can use `relative_focus` or `relative_pointer` to show the bar in a monitor where a window is focused or in monitor with a pointer respectively.
It also has fix #42 and closes #38 and maybe #37.
